### PR TITLE
remove not necessary call of dd-agent in docker compose

### DIFF
--- a/docker-compose-yaml-1
+++ b/docker-compose-yaml-1
@@ -1,7 +1,7 @@
 datadog:
   image: datadog/docker-dd-agent
   environment:
-    - API_KEY
+    - API_KEY={INSERT YOUR API KEY HERE}
   privileged: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-yaml-1
+++ b/docker-compose-yaml-1
@@ -9,4 +9,3 @@ datadog:
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
   ports:
     - "8125:8125"
-  command: dd-agent foreground

--- a/docker-compose-yaml-2
+++ b/docker-compose-yaml-2
@@ -9,7 +9,6 @@ datadog:
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
   ports:
     - "8125:8125"
-  command: dd-agent foreground
 
 first:
   image: first

--- a/docker-compose-yaml-2
+++ b/docker-compose-yaml-2
@@ -1,7 +1,7 @@
 datadog:
   image: datadog/docker-dd-agent
   environment:
-    - API_KEY
+    - API_KEY={INSERT YOUR API KEY HERE}
   privileged: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-yaml-3
+++ b/docker-compose-yaml-3
@@ -3,7 +3,7 @@ datadog:
   links:
     - web
   environment:
-    - API_KEY
+    - API_KEY={INSERT YOUR API KEY HERE}
   privileged: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-yaml-3
+++ b/docker-compose-yaml-3
@@ -11,7 +11,6 @@ datadog:
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
   ports:
     - "8125:8125"
-  command: dd-agent foreground
 
 web:
   build: web

--- a/docker-compose-yaml-4
+++ b/docker-compose-yaml-4
@@ -3,7 +3,7 @@ datadog:
   links:
     - web
   environment:
-    - API_KEY
+    - API_KEY={INSERT YOUR API KEY HERE}
   privileged: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-yaml-4
+++ b/docker-compose-yaml-4
@@ -11,7 +11,6 @@ datadog:
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
   ports:
     - "8125:8125"
-  command: dd-agent foreground
 
 web:
   build: web

--- a/docker-compose-yaml-5
+++ b/docker-compose-yaml-5
@@ -12,7 +12,6 @@ datadog:
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
   ports:
     - "8125:8125"
-  command: dd-agent foreground
 
 web:
   build: web

--- a/docker-compose-yaml-5
+++ b/docker-compose-yaml-5
@@ -4,7 +4,7 @@ datadog:
     - web
     - loadbalancer
   environment:
-    - API_KEY
+    - API_KEY={INSERT YOUR API KEY HERE}
   privileged: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-yaml-6
+++ b/docker-compose-yaml-6
@@ -12,7 +12,6 @@ datadog:
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
   ports:
     - "8125:8125"
-  command: dd-agent foreground
 
 web:
   build: web

--- a/docker-compose-yaml-6
+++ b/docker-compose-yaml-6
@@ -4,7 +4,7 @@ datadog:
     - web
     - loadbalancer
   environment:
-    - API_KEY
+    - API_KEY={INSERT YOUR API KEY HERE}
   privileged: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
In this pull request I fix bug with unnecessary call of dd-agent that produces error while starting container.